### PR TITLE
Improve performance defaults

### DIFF
--- a/exp1/index.html
+++ b/exp1/index.html
@@ -18,11 +18,11 @@ World</textarea>
         </div>
         <div class="slider-container">
           <label for="tilesX">Tiles X: <span id="tilesXValue">16</span></label>
-          <input type="range" id="tilesX" min="1" max="80" value="16" step="1">
+          <input type="range" id="tilesX" min="1" max="40" value="16" step="1">
         </div>
         <div class="slider-container">
           <label for="tilesY">Tiles Y: <span id="tilesYValue">16</span></label>
-          <input type="range" id="tilesY" min="1" max="80" value="16" step="1">
+          <input type="range" id="tilesY" min="1" max="40" value="16" step="1">
         </div>
         <div class="slider-container">
           <label for="speed">Speed: <span id="speedValue">0.005</span></label>

--- a/exp1/sketch.js
+++ b/exp1/sketch.js
@@ -18,6 +18,7 @@ let sliderValues = {};
 function setup() {
   const canvas = createCanvas(400, 400);
   canvas.parent('canvas-container');
+  pixelDensity(1);
   pg = createGraphics(400, 400);
   
   // Initialize text input

--- a/exp2/index.html
+++ b/exp2/index.html
@@ -18,11 +18,11 @@ World</textarea>
         </div>
         <div class="slider-container">
           <label for="tilesX">Tiles X: <span id="tilesXValue">16</span></label>
-          <input type="range" id="tilesX" min="1" max="80" value="16" step="1">
+          <input type="range" id="tilesX" min="1" max="40" value="16" step="1">
         </div>
         <div class="slider-container">
           <label for="tilesY">Tiles Y: <span id="tilesYValue">16</span></label>
-          <input type="range" id="tilesY" min="1" max="80" value="16" step="1">
+          <input type="range" id="tilesY" min="1" max="40" value="16" step="1">
         </div>
         <div class="slider-container">
           <label for="speed">Speed: <span id="speedValue">0.005</span></label>

--- a/exp2/sketch.js
+++ b/exp2/sketch.js
@@ -35,6 +35,7 @@ function preload() {
 function setup() {
   const canvas = createCanvas(400, 400);
   canvas.parent('canvas-container');
+  pixelDensity(1);
   pg = createGraphics(400, 400);
   
   // Set initial font


### PR DESCRIPTION
## Summary
- limit tile sliders to 40 tiles instead of 80
- reduce rendering cost by forcing `pixelDensity(1)` in both sketches

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840d45df3208321a5c42f37bfb1cd0f